### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/.circleci/orb/orb.yml
+++ b/.circleci/orb/orb.yml
@@ -2,8 +2,10 @@
 # See https://docs.nowsecure.com/auto/integration-services/jenkins-integration/
 # https://github.com/nowsecure/auto-circleci-plugin
 version: 2.1
-description: CircleCI orb for NowSecure AUTO that provides fully automated, mobile
-  appsec testing coverage
+description: NowSecure AUTO provides fully automated, mobile appsec testing coverage
+display:
+  source_url: https://github.com/nowsecure/auto-circleci-plugin
+  home_url: https://www.nowsecure.com/
 executors:
   default:
     description: Java docker container to use when running the NowSecure AUTO orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Removed redundant reference to CircleCI from the description.